### PR TITLE
Update block_moving

### DIFF
--- a/jumpsplat120/block_moving.dsc
+++ b/jumpsplat120/block_moving.dsc
@@ -61,7 +61,7 @@ spawn_carryable_block:
         # Play particles at the blocks location. They stop when the entity despawns. Despawn all entities in the
         # area with a "carryable" flag for clean up.
         - while <[entities].first.is_spawned>:
-            - playeffect effect:wax_off at:<[entities].first.location.up[1.25]> quantity:15 offset:0.45,0.45,0.45
+            - playeffect effect:wax_off at:<[entities].first.location.up[1.25]> quantity:15 offset:0.45,0.45,0.45 visibility:64
             - repeat 10:
                 - wait 1t
                 - while stop if:<[entities].first.is_spawned.not>

--- a/jumpsplat120/block_moving.dsc
+++ b/jumpsplat120/block_moving.dsc
@@ -1,44 +1,43 @@
 block_carrying_events:
     type: world
+    debug: false
     events:
-        on player right clicks shulker entity_flagged:carryable:
-            #put carryable above head, remove the actual shulker block so it doesn't prevent movement
+        on player right clicks entity_flagged:carryable:
             - ratelimit player 1t
             - if !<player.has_flag[carrying]>:
+                #put carryable above head
                 - flag player carrying
                 - define stand <context.entity.vehicle>
-                - remove <[stand].passengers.filter[is_mob]>
                 - mount <[stand]>|<player>
+            - else:
+                #When the block is above you, the armor stand gets in the way of clicking 99% of the time, so we actually have to
+                #do on click armor stand and some raytrace logic to work around that.
+                - inject block_carrying_events path:handle_block
         on player right clicks block:
-            - inject block_carrying_events path:handle_block
-        on player right clicks armor_stand entity_flagged:carryable:
-            #When the block is above you, the armor stand gets in the way of clicking 99% of the time, so we actually have to
-            #do on click armor stand and some raytrace logic to work around that.
             - inject block_carrying_events path:handle_block
     handle_block:
         - if <player.has_flag[carrying]>:
+            - flag player carrying:!
             # Get location due to armor stand bounding box shenanigans...
             - define location <player.cursor_on[4.5].center>
-            - flag player carrying:!
-            - define stand <player.passenger>
-            # Unmount stand, readd the shulker...
-            - mount cancel <[stand]>
-            - adjust <[stand]> passengers:<[stand].passenger>|lib_entity_shulker
-            - define is_pressure_plate <[location].material.name.equals[light_weighted_pressure_plate]>
+            - define stand    <player.passenger>
+            - define is_plate <[location].material.name.equals[light_weighted_pressure_plate]>
             # if we click on the ground, put it one block above the block we clicked. in the case of a pressure plate
             # we actually want to shift it down into the pressure plate, since the pressure plate is "taking up" that blocks space
-            - define location <[location].down[<[is_pressure_plate].if_true[1].if_false[0.25]>]>
+            - define location <[location].down[<[is_plate].if_true[1].if_false[0.25]>]>
+            - mount cancel <[stand]>
             - teleport <[stand]> <[location]>
             - playsound <[location]> sound:BLOCK_COPPER_PLACE pitch:<proc[lib_random_pitch]> sound_category:BLOCKS
             # Play animation for when the block is placed on a pressure plate.
-            - if <[is_pressure_plate]>:
-                - ~run make_path def:circ|inout|<[location].up[1.25]>|<[location].up[1.75]>|15|temp save:path_a
-                - ~run make_path def:bounce|out|<[location].up[1.75]>|<[location].up[0.95]>|10|temp save:path_b
-                - define path_a <entry[path_a].created_queue.determination.first>
-                - define path_b <entry[path_b].created_queue.determination.first>
+            - if <[is_plate]>:
+                - ~run make_path def:circ|inout|<[location].up[1.25]>|<[location].up[2]>|40|temp
+                - define path_a <server.flag[path.temp]>
+                - ~run make_path def:bounce|out|<[location].up[2]>|<[location].up[1.1]>|60|temp
+                - define path_b <server.flag[path.temp]>
                 # Only get half of each path, since normally a path is from A -> B -> A
-                - define path_a <[path_a].get[1].to[<[path_a].size.mul[0.5]>]>
-                - define path_b <[path_b].get[1].to[<[path_b].size.mul[0.5]>]>
+                - define path_a <[path_a].get[1].to[<[path_a].size.mul[0.5].round>]>
+                - define path_b <[path_b].get[1].to[<[path_b].size.mul[0.5].round>]>
+                - define two_thirds <[path_b].size.mul[0.66].round>
                 - wait 10t
                 - foreach <[path_a]>:
                     - teleport <[stand]> <[value]>
@@ -47,8 +46,9 @@ block_carrying_events:
                 - foreach <[path_b]>:
                     - teleport <[stand]> <[value]>
                     - wait 1t
-                # Cluh clunk
-                - playsound <[location]> sound:BLOCK_IRON_DOOR_CLOSE pitch:0.5
+                    - if <[two_thirds]> == <[loop_index]>:
+                        # Cluh clunk
+                        - playsound <[location]> sound:BLOCK_IRON_DOOR_CLOSE pitch:0.5
 
 spawn_carryable_block:
     type: task


### PR DESCRIPTION
- Fixed !itworks switch that I was using
- No longer remove the shulker from the block when carrying. It's not actually needed
- Bit of reorginizing defines and stuff
- Paths no longer determine. So we get the paths from the temp flag.
- Paths needed to be rounded, since sometime they could be odd
- play sound at the two thirds part of path_b
- Animations are slower to get the full bounce effect from the block
- Block sits slightly above pressure plate, 1 to see the plate so that way players don't forget it's sitting on one, and two, because falling blocks that move into the pressure plate like to pop off