### PR TITLE
Burning leaves script + update utilities

### DIFF
--- a/jumpsplat120/burning_leaves.dsc
+++ b/jumpsplat120/burning_leaves.dsc
@@ -1,0 +1,27 @@
+burning_leaves:
+    type: world
+    events:
+        on player shoots *_leaves in:box:
+            - define cuboid <cuboid[box]>
+            - inject burning_leaves path:burn_task
+    burn_task:
+        # if arrow is on fire...
+        - if <context.projectile.on_fire>:
+            # get all leaves in the cuboid, flagged with the burn group flag that matches the impact's burn group
+            # (a shrine might have more than one leaf burning puzzle, so we only want to get the one), then remove
+            # all flagged leaf blocks, since they've already been ignited (so we don't try to ignite twice), then
+            # sort by distance.
+            - define leaves <[cuboid].blocks_flagged[burn_group].filter[has_flag[ignited].not].filter[flag[burn_group].equals[<context.location.flag[burn_group]>]].proc[lib_sort_by_distance_to].context[<context.location>]>
+            # Flags all leaves so they don't get double ignited...
+            - flag <[leaves]> ignited expire:1m
+            # run the modifyblock, but with varying levels of delay, based off of where in the loop it is.
+            # That will make it so the fire spreads out from the impact location. Also, pass in a def of the
+            # air block, which is calculated by finding which face isn't exposed by air, subtracting that location
+            # from the original location, which gives a vector for the face opposite of that location, then using
+            # that vector to get the location of where the fire should be
+            - foreach <[leaves]>:
+                - run burning_leaves path:remove def.leaf_block:<[value]> def.air_block:<[value].add[<[value].sub[<[value].proc[lib_surrounding_blocks].filter[material.advanced_matches[air].not].first>]>]> delay:<util.random.int[<[loop_index].mul[4]>].to[<[loop_index].mul[8]>]>t
+    remove:
+        - modifyblock <[air_block]> fire
+        - wait <util.random.int[5].to[15]>t
+        - modifyblock <[leaf_block]> air

--- a/utilities/bin/core/procedures.dsc
+++ b/utilities/bin/core/procedures.dsc
@@ -79,7 +79,7 @@ lib_core_bo:
     debug: false
     definitions: value
     script:
-        - determine bo <tern[<[value].is[LESS].than[.363636363]>].pass[<element[7.5625].mul[<[value]>].mul[<[value]>]>].fail[<tern[<[value].is[LESS].than[.727272727]>].pass[<element[7.5625].mul[<[value].sub[.5454545]>].mul[<[value].sub[.5454545]>].add[.75]>].fail[<tern[<[value].is[LESS].than[.909090909]>].pass[<element[7.5625].mul[<[value].sub[.81818181]>].mul[<[value].sub[.81818181]>].add[0.9375]>].fail[<element[7.5625].mul[<[value].sub[.95454545]>].mul[<[value].sub[.95454545]>].add[0.984375]>]>]>]>
+        - determine <tern[<[value].is[LESS].than[.363636363]>].pass[<element[7.5625].mul[<[value]>].mul[<[value]>]>].fail[<tern[<[value].is[LESS].than[.727272727]>].pass[<element[7.5625].mul[<[value].sub[.5454545]>].mul[<[value].sub[.5454545]>].add[.75]>].fail[<tern[<[value].is[LESS].than[.909090909]>].pass[<element[7.5625].mul[<[value].sub[.81818181]>].mul[<[value].sub[.81818181]>].add[0.9375]>].fail[<element[7.5625].mul[<[value].sub[.95454545]>].mul[<[value].sub[.95454545]>].add[0.984375]>]>]>]>
 
 #Gets an error type from core/data, and the name of the script calling the proc
 #so it can print out errors. Also takes unlisted arguments that are change depending

--- a/utilities/bin/procedures/various.dsc
+++ b/utilities/bin/procedures/various.dsc
@@ -7,6 +7,8 @@
 # center_on_head: Does what it says on the tin; returns a location where the armor stand is centered on the head. This returns the center of a block, so you will most likely need to adjust seperately after using this procedure.
 # block_face: Get's the face of a block that the passed entity is looking up, up to the range passed. If there is no passed entity, attempts to fallback to a linked player, and if there is no range, uses the default of 200.
 # block_facing: Get's the facing vector of the block at location.
+# surrounding_blocks: Helper function that gets all the blocks surrounding a location. Faster than using a .find function, since it's just doing some basic vector math. Does NOT return the location itself.
+# sort_by_distance_to: Sorts a list of location by their distance to another location.
 # rainbow_list: Returns a list of just colors. Similar to rainbow text, but doesn't need text, so you can use the colors however and have them be to your spec.
 # unstackable: Takes a passed item name, and returns an item with random nbt on it, so it doesn't stack with other items of the same type. Useful for creating non stacking items out of a material that normally stacks, when you don't want to adjust the material in it's entirety.
 # face_to_vector: Takes a face (up/down/north/south/east/west) and turns it into a vector (0,1,0/0,-1,0...)
@@ -46,8 +48,9 @@ lib_outline_cuboid:
         - define density <tern[<[density].if_null[true]>].pass[1].fail[<[density]>]>
         - if <[cuboid].list_members.size> == 1:
             - define density <element[1].div[<[density]>]>
-            - define max     <[cuboid].max_y.add[0.51,0.51,0.51]>
-            - define min     <[cuboid].min_y.sub[0.51,0.51,0.51]>
+            - define world   <[cuboid].center.world>
+            - define max     <[cuboid].max.center.add[.51,.51,.51,<[world]>]>
+            - define min     <[cuboid].min.center.sub[.51,.51,.51,<[world]>]>
             - define a       <[max].with_z[<[min].z>]>
             - define b       <[max].with_x[<[min].x>]>
             - define c       <[b].with_z[<[min].z>]>
@@ -114,6 +117,15 @@ lib_block_facing:
         - define entity <[entity].if_null[<player>]>
         - determine <[entity].eye_location.precise_impact_normal[<[distance].if_null[200]>]>
 
+lib_surrounding_blocks:
+    type: procedure
+    debug: false
+    definitions: location
+    script:
+        - foreach <list[1,0,0|0,1,0|0,0,1|-1,0,0|0,-1,0|0,0,-1]>:
+            - define result:->:<[location].add[<[value]>]>
+        - determine <[result]>
+
 lib_rainbow_list:
     type: procedure
     debug: false
@@ -125,6 +137,22 @@ lib_rainbow_list:
             - define color_list:->:<&color[<[color]>]>
             - define color <[color].with_hue[<[color].hue.add[15]>]>
         - determine <[color_list]>
+
+lib_sort_by_distance_to:
+    type: procedure
+    debug: false
+    definitions: list|location
+    script:
+        - define result <list>
+        - foreach <[list]> as:loc:
+            - define distance <[loc].distance[<[location]>]>
+            - define index 1
+            - foreach <[result]> as:compare_loc:
+                - if <[distance]> <= <[compare_loc].distance[<[location]>]>:
+                    - foreach stop
+                - define index:++
+            - define result <[result].insert[<[loc]>].at[<[index]>]>
+        - determine <[result]>
 
 lib_full_volume:
     type: procedure


### PR DESCRIPTION
# Utilities
- Fixed bounce script (tried to determine with define syntax)
- Fixed cuboid_outline (was fiddling with it and broke it, idr why, but now it's fixed)
- surrounding_blocks proc
- sort_by_distance_to proc

#burning_leaves
Whenever there's a new set of leaves to be burned, add the three relevant lines to the events (on player shoots *_leaves in:area, and the define and inject). The define assumes a cuboid, but the only tag used is blocks_flagged, so you can actually use any AreaObject. You still have to call it cuboid though because that's what the burn task uses. 

Then it, if the projectile is on fire, gets all the relevant leaves. In this case, that's all leaves in the area that are flagged with `burn_group`. if the leaf hit is in burn group A, it gets all `burn_group:a` leaves. Leaves can only be in one burn group. Then, the list is sorted by distance to which block was hit, so the fire spread will spread from there. The leaves are flagged with `ignited`, so that they don't get "double ignited".  Then the leaves run through the remove task one at a time, consecutively, with a small delay between them all. So the first one will wait 4-8 ticks, and the next one will wait 8-16 ticks (4-8 ticks after the first block) and so on. Also, since the fire spread is not on in dungeons, the leaf blocks are manually removed as well.