### PR TITLE
Add falling block chunks, other minor  stuff

### DIFF
--- a/jumpsplat120/block_moving.dsc
+++ b/jumpsplat120/block_moving.dsc
@@ -52,8 +52,8 @@ block_carrying_events:
 
 spawn_carryable_block:
     type: task
-    definitions: material|location
     debug: false
+    definitions: material|location
     script:
         - run lib_spawn_falling_block def:<[material]>|<[location].add[-0.01,-1.25,0.01]> save:block
         - define entities <entry[block].created_queue.determination.last>

--- a/jumpsplat120/burning_leaves.dsc
+++ b/jumpsplat120/burning_leaves.dsc
@@ -1,5 +1,6 @@
 burning_leaves:
     type: world
+    debug: false
     events:
         on player shoots *_leaves in:box:
             - define cuboid <cuboid[box]>
@@ -22,6 +23,6 @@ burning_leaves:
             - foreach <[leaves]>:
                 - run burning_leaves path:remove def.leaf_block:<[value]> def.air_block:<[value].add[<[value].sub[<[value].proc[lib_surrounding_blocks].filter[material.advanced_matches[air].not].first>]>]> delay:<util.random.int[<[loop_index].mul[4]>].to[<[loop_index].mul[8]>]>t
     remove:
-        - modifyblock <[air_block]> fire
-        - wait <util.random.int[5].to[15]>t
+        - modifyblock <[air_block]> fire[faces=<[leaf_block].sub[<[air_block]>].vector_to_face>]
+        - wait <util.random.int[10].to[15]>t
         - modifyblock <[leaf_block]> air

--- a/jumpsplat120/falling_block_chunks.dsc
+++ b/jumpsplat120/falling_block_chunks.dsc
@@ -1,0 +1,25 @@
+falling_chunks:
+    type: task
+    debug: false
+    definitions: location
+    script:
+        # falling_blocks have a weird offset...
+        - define location <[location].center.sub[0,0.5,0]>
+        # build chunk...
+        - define design <queue.definition_map.get[raw_context].get[2].to[last]>
+        - define materials <[design].get_sub_items[1].split_by[;]>
+        - foreach <[design].get_sub_items[2].split_by[;]> as:offset:
+            - spawn falling_block[fallingblock_type=<[materials].get[<[loop_index]>]>] <[location].add[<[offset]>]> persistent save:block
+            - define blocks:->:<entry[block].spawned_entity>
+        - adjust <[blocks]> gravity:false
+        # get lowest blocks in the chunk, then check to see if it's supported, and if not,
+        # remove it from the list. One, because we don't need to keep checking blocks we
+        # know aren't supported anymore (because you can't build in the dungeon), but
+        # also because once the list is empty, we know the platform is no longer suspended.
+        - define lowest <[blocks].filter[location.y.equals[<[blocks].sort_by_number[y].first.location.y>]].filter[location.center.down.material.is_solid]>
+        # while it should be suspended...
+        - while <[lowest].size> > 0:
+            # filter by supported...
+            - define lowest <[lowest].filter[location.center.down.material.is_solid]>
+            - wait 5t
+        - adjust <[blocks]> gravity:true


### PR DESCRIPTION
- Added falling chunks script. This is a script that spawns in a falling block that needs to be supported on the bottom. If the structure is not supported, the whole thing falls.
- Tweaked wait on burning leaves (leaves would burn out before the next one caught on fire, looking like some leaves were catching fire spontaneously)
- added getting the face so that the fire wasn't a suspended fire block, but was "attached" to the leaf block.
- Added debug:false to everything